### PR TITLE
Support array values for fronmatter title property

### DIFF
--- a/main.js
+++ b/main.js
@@ -1482,12 +1482,18 @@ var BaseScanner = class {
   }
   get_meta_value(file, prop) {
     let metadata = this.app.metadataCache.getFileCache(file);
-    if (metadata && metadata.frontmatter) {
-      if (prop in metadata.frontmatter) {
-        let value = metadata.frontmatter[prop];
-        return _is_string(value) ? value : null;
+    if ((metadata == null ? void 0 : metadata.frontmatter) && prop in metadata.frontmatter) {
+      let value = metadata.frontmatter[prop];
+      if (typeof value === "string")
+        return value;
+      if (Array.isArray(value) && value.length > 0) {
+        let first = value[0];
+        if (typeof first === "string")
+          return first;
       }
+      return null;
     }
+    return null;
   }
   // can we get it from Note class?
   get_note_title(file) {

--- a/src/base_scanner.ts
+++ b/src/base_scanner.ts
@@ -132,18 +132,25 @@ export class BaseScanner
         });
     }
 
-    get_meta_value(file:TFile, prop:string)
+    get_meta_value(file:TFile, prop:string): string | null
     {
         let metadata = this.app.metadataCache.getFileCache(file);
 
-        if(metadata && metadata.frontmatter)
+        if(metadata?.frontmatter && prop in metadata.frontmatter)
         {
-            if(prop in metadata.frontmatter)
-            {
-                let value = metadata.frontmatter[prop];
-                return _is_string(value) ? value : null;
+            let value = metadata.frontmatter[prop];
+
+            if (typeof value === 'string') return value;
+
+            if (Array.isArray(value) && value.length > 0) {
+                let first = value[0];
+                if (typeof first === 'string') return first;
             }
+
+            return null;
         }
+
+        return null;
     }
 
     // can we get it from Note class?


### PR DESCRIPTION
Users may have multiple titles for notes in an array format.
I have modified `get_meta_value()` in src/base_scanner.ts to extract the first string element in this case

enabling formats like this

```yaml
titles:
  - Primary Title
  - Secondary Title
```